### PR TITLE
Fix for Issue #4

### DIFF
--- a/css-lite.lisp
+++ b/css-lite.lisp
@@ -133,7 +133,7 @@ There are three possible values:
 
 (defun process-css-rule (rule &key (parent-selectors nil))
   (let ((selectors (if parent-selectors
-                       (flatten (list parent-selectors (car rule)))
+                       (concatenate 'list parent-selectors (car rule))
                        (car rule)))
         (properties (cadr rule))
         (children-rules (cddr rule)))


### PR DESCRIPTION
Right now it throws everything in a list and then flattens.  This breaks compound specifiers.

Just concatenating the lists should do the Right Thing.  Let me know if I'm wrong.
