### PR TITLE
Fix: parenscript dependency, package qualifier for process-css-properties

### DIFF
--- a/css-lite.asd
+++ b/css-lite.asd
@@ -1,6 +1,7 @@
 ;;; -*- Mode: LISP; Syntax: COMMON-LISP; Package: CL-USER; Base: 10 -*-
 
 (asdf:defsystem :css-lite
+  :depends-on ("parenscript")
   :serial t
   :version "0.01"
   :components ((:file "package")

--- a/paren-css-lite.lisp
+++ b/paren-css-lite.lisp
@@ -9,11 +9,11 @@
                 `(ps:+ ,val "pt"))
 
 #+parenscript (ps:defpsmacro css (&body rules)
-                (cons 'ps:+ (ps::concat-constant-strings (mapcan #'process-css-rule rules))))
+                (cons 'ps:+ (ps::concat-constant-strings (mapcan #'css-lite::process-css-rule rules))))
 
 
 #+parenscript (ps:defpsmacro inline-css (&rest properties)
-                (cons 'ps:+ (ps::concat-constant-strings (process-css-properties properties nil :newlines nil))))
+                (cons 'ps:+ (ps::concat-constant-strings (css-lite::process-css-properties properties nil :newlines nil))))
 
 
 #+parenscript (ps:defpsmacro to-string (x)


### PR DESCRIPTION
The first commit lets `asdf`/`quicklisp` load `parenscript` automatically if not loaded yet. 

The second commit silences a style warning (sbcl, `asdf:load-system`) for undefined function. The function `process-css-properties` needs the double colon package qualifier `css-lite`.